### PR TITLE
Introduce SIMPLE_SERIAL_SHELL_BUFSIZE to make it configurable

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -1,0 +1,13 @@
+# SimpleSerialShell Configuration
+## Input buffer size
+The predefined size of input buffer is 88 bytes (defined by the ``SIMPLE_SERIAL_SHELL_BUFSIZE`` identifier). It's ok in most cases, but when it's not enough, you can redefine it with build options.
+Check your IDE documentation to learn how to properly redefine build options. See the example for PlatformIO below.
+
+### Arduino IDE:
+Configuring buffer size from within the Arduino IDE is not recommended.
+
+### PlatformIO:
+Define a new value at your `platformio.ini` in this way:
+```ini
+build_flags = -D SIMPLE_SERIAL_SHELL_BUFSIZE=128
+```

--- a/src/SimpleSerialShell.cpp
+++ b/src/SimpleSerialShell.cpp
@@ -38,7 +38,7 @@ class SimpleSerialShell::Command {
         int compareName(const char * aName) const
         {
             const String myNameString(name);
-            int comparison = strncasecmp(myNameString.c_str(), aName, BUFSIZE);
+            int comparison = strncasecmp(myNameString.c_str(), aName, SIMPLE_SERIAL_SHELL_BUFSIZE);
             return comparison;
         };
 
@@ -160,7 +160,7 @@ bool SimpleSerialShell::prepInput(void)
                 // Otherwise, echo the character and append it to the buffer
                 linebuffer[inptr++] = c;
                 write(c);
-                if (inptr >= BUFSIZE-1) {
+                if (inptr >= SIMPLE_SERIAL_SHELL_BUFSIZE-1) {
                     bufferReady = true; // flush to avoid overflow
                 }
                 break;
@@ -174,7 +174,7 @@ bool SimpleSerialShell::prepInput(void)
 int SimpleSerialShell::execute(const char commandString[])
 {
     // overwrites anything in linebuffer; hope you don't need it!
-    strncpy(linebuffer, commandString, BUFSIZE);
+    strncpy(linebuffer, commandString, SIMPLE_SERIAL_SHELL_BUFSIZE);
     return execute();
 }
 
@@ -182,7 +182,7 @@ int SimpleSerialShell::execute(const char commandString[])
 int SimpleSerialShell::execute(void)
 {
     char * argv[MAXARGS] = {0};
-    linebuffer[BUFSIZE - 1] = '\0'; // play it safe
+    linebuffer[SIMPLE_SERIAL_SHELL_BUFSIZE - 1] = '\0'; // play it safe
     int argc = 0;
 
     char * rest = NULL;

--- a/src/SimpleSerialShell.h
+++ b/src/SimpleSerialShell.h
@@ -2,6 +2,10 @@
 #ifndef SIMPLE_SERIAL_SHELL_H
 #define SIMPLE_SERIAL_SHELL_H
 
+#ifndef SIMPLE_SERIAL_SHELL_BUFSIZE
+#define SIMPLE_SERIAL_SHELL_BUFSIZE 88
+#endif
+
 ////////////////////////////////////////////////////////////////////////////////
 /*!
  *  @file SimpleSerialShell.h
@@ -56,9 +60,8 @@ class SimpleSerialShell : public Stream {
         bool prepInput(void);
 
         int report(const __FlashStringHelper * message, int errorCode);
-        static const char BUFSIZE = 88;
         static const char MAXARGS = 10;
-        char linebuffer[BUFSIZE];
+        char linebuffer[SIMPLE_SERIAL_SHELL_BUFSIZE];
         int inptr;
 
         class Command;


### PR DESCRIPTION
Hi,

There is default limit in 88 bytes as maximum input line length, but it's not enough for our needs.

These changes add possibility to redefine that limit with build flags.  Example for PlatformIO:
```build_flags = -D SIMPLE_SERIAL_SHELL_BUFSIZE=256```

P.S. Thanks for simple, but quite useful lib :)