### PR TITLE
Pj/build cleanup

### DIFF
--- a/examples/AdjustableBlink/AdjustableBlink.ino
+++ b/examples/AdjustableBlink/AdjustableBlink.ino
@@ -9,9 +9,10 @@
 //         "strings together"
 //         (improves readability for very long strings)
 //
-int showID(int argc = 0, char**argv = NULL)
+int showID(int /*argc*/ = 0, char** /*argv*/ = NULL)
 {
     shell.println(F( "Running " __FILE__ ",\nBuilt " __DATE__));
+    return 0;
 };
 
 
@@ -25,7 +26,7 @@ void toggleLED_nb(void)
     static auto lastToggle = millis();  // saved between calls
     auto now = millis();
 
-    if (now - lastToggle > togglePeriod / 2)
+    if (now - lastToggle > (unsigned int) (togglePeriod / 2) )
     {
         // toggle
         digitalWrite(LED_BUILTIN, !digitalRead(LED_BUILTIN));
@@ -49,7 +50,7 @@ int setTogglePeriod(int argc, char **argv)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-int getTogglePeriod(int argc, char **argv)
+int getTogglePeriod(int /*argc*/ , char ** /*argv*/ )
 {
     shell.print("LED toggle period is ");
     shell.print(togglePeriod);

--- a/examples/ArduinoTextInterface/ArduinoCommands.cpp
+++ b/examples/ArduinoTextInterface/ArduinoCommands.cpp
@@ -23,7 +23,7 @@ int badArgCount( char * cmdName )
 //
 struct lookupVals
 {
-  char * name;
+  const char * name;
   int val;
 };
 
@@ -81,12 +81,12 @@ int analogRead(int argc, char **argv)
 {
   if (argc == 2)
   {
-    auto pin = atoi(argv[1]);
-    if (pin < 0 || pin > NUM_ANALOG_INPUTS)
+    int pin = atoi(argv[1]);
+    if (pin < 0 || pin > (unsigned int) NUM_ANALOG_INPUTS)
     {
-      shell.print("pin ");
+      shell.print(F("pin "));
       shell.print(pin);
-      shell.println(" does not look like an analog pin");
+      shell.println(F(" does not look like an analog pin"));
     }
     auto val = analogRead(pin);
     shell.println(val);
@@ -105,9 +105,9 @@ int analogWrite(int argc, char **argv)
     int pin = atoi(argv[1]);
     if (!digitalPinHasPWM(pin))
     {
-      shell.print("pin ");
+      shell.print(F("pin "));
       shell.print(pin);
-      shell.println(" does not look like an analog output");
+      shell.println(F(" does not look like an analog output"));
     }
     int val = atoi(argv[2]);
 
@@ -129,12 +129,12 @@ int digitalWrite(int argc, char **argv)
 {
   if (argc == 3)
   {
-    auto pin = atoi(argv[1]);
+    int pin = atoi(argv[1]);
     if (pin < 0 || pin > NUM_DIGITAL_PINS)
     {
-      shell.print("pin ");
+      shell.print(F("pin "));
       shell.print(pin);
-      shell.println(" does not look like a digital pin");
+      shell.println(F(" does not look like a digital pin"));
     }
     auto level = lookup(argv[2], digLevels);
 
@@ -150,12 +150,12 @@ int digitalRead(int argc, char **argv)
 {
   if (argc == 2)
   {
-    auto pin = atoi(argv[1]);
+    int pin = atoi(argv[1]);
     if (pin < 0 || pin > NUM_DIGITAL_PINS)
     {
-      shell.print("pin ");
+      shell.print(F("pin "));
       shell.print(pin);
-      shell.println(" does not look like a digital pin");
+      shell.println(F(" does not look like a digital pin"));
     }
     auto val = digitalRead(pin);
     shell.print(val);

--- a/examples/ArduinoTextInterface/ArduinoTextInterface.ino
+++ b/examples/ArduinoTextInterface/ArduinoTextInterface.ino
@@ -10,9 +10,10 @@
 //         "strings together"
 //         (improves readability for very long strings)
 //
-int showID(int argc=0, char**argv=NULL)
+int showID(int /*argc*/ =0, char** /*argv*/=NULL)
 {
   shell.println(F( "Running " __FILE__ ", Built " __DATE__));
+  return 0;
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/examples/EchoCommand/EchoCommand.ino
+++ b/examples/EchoCommand/EchoCommand.ino
@@ -9,9 +9,10 @@
 //         "strings together"
 //         (improves readability for very long strings)
 //
-int showID(int argc = 0, char**argv = NULL)
+int showID(int /*argc*/ = 0, char** /*argv*/ = NULL)
 {
     shell.println(F( "Running " __FILE__ ", Built " __DATE__));
+    return 0;
 };
 
 

--- a/examples/IdentifyTheSketch/IdentifyTheSketch.ino
+++ b/examples/IdentifyTheSketch/IdentifyTheSketch.ino
@@ -9,9 +9,10 @@
 //         "strings together"
 //         (improves readability for very long strings)
 //
-int showID(int argc = 0, char**argv = NULL)
+int showID(int /*argc*/ = 0, char** /*argv*/ = NULL)
 {
     shell.println(F( "Running " __FILE__ ", Built " __DATE__));
+    return 0;
 };
 
 

--- a/extras/tests/simpleSerialShellTest/simpleSerialShellTest.ino
+++ b/extras/tests/simpleSerialShellTest/simpleSerialShellTest.ino
@@ -251,7 +251,7 @@ testF(ShellTest, delete) {
 
 //////////////////////////////////////////////////////////////////////////////
 // ... so which sketch is this?
-int showID(int argc = 0, char **argv = NULL)
+int showID(int /*argc*/ = 0, char ** /*argv*/ = NULL)
 {
     Serial.println();
     Serial.println(F( "Running " __FILE__ ", Built " __DATE__));

--- a/src/SimpleSerialShell.cpp
+++ b/src/SimpleSerialShell.cpp
@@ -263,7 +263,7 @@ void SimpleSerialShell::resetBuffer(void)
 // SimpleSerialShell::printHelp() is a static method.
 // printHelp() can access the linked list of commands.
 //
-int SimpleSerialShell::printHelp(int argc, char **argv)
+int SimpleSerialShell::printHelp(int /*argc*/, char ** /*argv*/)
 {
     shell.println(F("Commands available are:"));
     auto aCmd = firstCommand;  // first in list of commands.


### PR DESCRIPTION
Automated build environments have made some changes that have started to cause build failures for this library.

For example a build environment may be set up to effectively "treat warnings as failures".  

In such cases, the "this argument was unused in the function" warning now breaks the build rather than being easy to ignore.

The purpose of this pull request is to clean up all those warnings.  Afterwards any warnings are new and interesting (and not hiding among other warnings).