### PR TITLE
Ensure input text completely matches command name to execute

### DIFF
--- a/extras/tests/HelpTest/HelpTest.ino
+++ b/extras/tests/HelpTest/HelpTest.ino
@@ -78,6 +78,51 @@ testF(HelpTest, helpTest)
 }
 
 //////////////////////////////////////////////////////////////////////////////
+// The goal of this test is to check a bug (#28) that was introduced when using 
+// a command that starts off with another.  
+testF(HelpTest, helpTest2) 
+{
+    // Notice that this command text is a superset of the "range" command
+    terminal.pressKeys("ranger 1 2\r");
+    assertTrue(shell.executeIfInput());
+
+    // The begining part of the response is the echo of the user's input.
+    assertEqual(terminal.getline(),  
+        ("ranger 1 2" NEW_LINE 
+        "\"ranger\": -1: command not found"
+        COMMAND_PROMPT));
+
+    // Notice that this command text is a subset of the "range" command
+    terminal.pressKeys("rang 1 2\r");
+    assertTrue(shell.executeIfInput());
+
+    // The begining part of the response is the echo of the user's input.
+    assertEqual(terminal.getline(),  
+        ("rang 1 2" NEW_LINE 
+        "\"rang\": -1: command not found"
+        COMMAND_PROMPT));
+
+    // Now check the normal command
+    terminal.pressKeys("range 1 2\r");
+    assertTrue(shell.executeIfInput());
+
+    // The begining part of the response is the echo of the user's input.
+    assertEqual(terminal.getline(),  
+        ("range 1 2"
+        COMMAND_PROMPT));
+
+    // Now check the normal command, except show that the comparison is 
+    // case-insensitive (per original implementation)
+    terminal.pressKeys("Range 1 2\r");
+    assertTrue(shell.executeIfInput());
+
+    // The begining part of the response is the echo of the user's input.
+    assertEqual(terminal.getline(),  
+        ("Range 1 2"
+        COMMAND_PROMPT));
+}
+
+//////////////////////////////////////////////////////////////////////////////
 // ... so which sketch is this?
 int showID(int /*argc*/ = 0, char ** /*argv*/ = NULL)
 {

--- a/src/SimpleSerialShell.cpp
+++ b/src/SimpleSerialShell.cpp
@@ -52,12 +52,11 @@ class SimpleSerialShell::Command {
             // strncasecmp_P.  That will take a bit of research since 
             // the header file may have a different name on ESP2886/ESP32.
             String work(nameAndDocs);
-            int compareLength = SIMPLE_SERIAL_SHELL_BUFSIZE;
             int delim = work.indexOf(' ');
-            if (delim >=0) {
-                compareLength = delim;
-            }
-            return strncasecmp(work.c_str(), aName, compareLength);
+            if (delim >= 0) {
+                work.remove(delim);
+            }            
+            return strncasecmp(work.c_str(), aName, SIMPLE_SERIAL_SHELL_BUFSIZE);
         };
 
         /**


### PR DESCRIPTION
Sorry about that!  This defect showed up during the testing of mesh radio network. 