### PR TITLE
Added functionality for Welcome Message

### DIFF
--- a/src/SimpleSerialShell.cpp
+++ b/src/SimpleSerialShell.cpp
@@ -83,6 +83,7 @@ class SimpleSerialShell::Command {
 SimpleSerialShell::SimpleSerialShell()
     : shellConnection(NULL),
       m_lastErrNo(EXIT_SUCCESS),
+      welcomeMessage(F("Welcome to SimpleSerialShell")),
       tokenizer(strtok_r)
 {
     // welcomeMessage =  (const __FlashStringHelper * ) const F("Welcome to SimpleSerialShell");

--- a/src/SimpleSerialShell.cpp
+++ b/src/SimpleSerialShell.cpp
@@ -85,8 +85,10 @@ SimpleSerialShell::SimpleSerialShell()
       m_lastErrNo(EXIT_SUCCESS),
       tokenizer(strtok_r)
 {
-    resetBuffer();
+    // welcomeMessage =  (const __FlashStringHelper * ) const F("Welcome to SimpleSerialShell");
 
+    resetBuffer();
+    
     // simple help.
     addCommand(F("help"), SimpleSerialShell::printHelp);
 };
@@ -120,7 +122,7 @@ bool SimpleSerialShell::executeIfInput(void)
     if (bufferReady) {
         didSomething = true;
         execute();
-	print(F("> ")); // provide command prompt feedback
+	    print(F("> ")); // provide command prompt feedback
     }
 
     return didSomething;
@@ -130,6 +132,11 @@ bool SimpleSerialShell::executeIfInput(void)
 void SimpleSerialShell::attach(Stream & requester)
 {
     shellConnection = &requester;
+
+    //Welcome message
+    shell.println(String(welcomeMessage));
+    
+    shell.print(F("> "));
 }
 
 //////////////////////////////////////////////////////////////////////////////
@@ -343,4 +350,9 @@ void SimpleSerialShell::flush()
 void SimpleSerialShell::setTokenizer(TokenizerFunction f)
 {
     tokenizer = f;
+}
+
+void SimpleSerialShell::setWelcomeMessage(const __FlashStringHelper * message)
+{
+    welcomeMessage = message;
 }

--- a/src/SimpleSerialShell.h
+++ b/src/SimpleSerialShell.h
@@ -82,9 +82,13 @@ class SimpleSerialShell : public Stream {
         // optional.
         void setTokenizer(TokenizerFunction f);
 
+        void setWelcomeMessage(const __FlashStringHelper * message);
+
     private:
 
         SimpleSerialShell(void);
+
+        const __FlashStringHelper * welcomeMessage = F("Welcome to SimpleSerialShell");;
 
         Stream * shellConnection;
         int m_lastErrNo;

--- a/src/SimpleSerialShell.h
+++ b/src/SimpleSerialShell.h
@@ -88,7 +88,7 @@ class SimpleSerialShell : public Stream {
 
         SimpleSerialShell(void);
 
-        const __FlashStringHelper * welcomeMessage = F("Welcome to SimpleSerialShell");;
+        const __FlashStringHelper * welcomeMessage;
 
         Stream * shellConnection;
         int m_lastErrNo;


### PR DESCRIPTION
Very cute uWu

![image](https://user-images.githubusercontent.com/40475862/176947701-bbf94824-1be6-4b02-a6ac-b08b9f7cfd06.png)

I set the default message to Welcome to SimpleSerialShell.

To change it, one has to use the function ```shell.setWelcomeMessage(F("NotSimpleSerialShell");``` before calling ```shell.attach(Serial);```.