### PR TITLE
Allow setting the maximum number of parameters

### DIFF
--- a/src/SimpleSerialShell.cpp
+++ b/src/SimpleSerialShell.cpp
@@ -93,13 +93,13 @@ SimpleSerialShell::SimpleSerialShell()
 };
 
 //////////////////////////////////////////////////////////////////////////////
-void setMaxArgs(char ma)
+void SimpleSerialShell::setMaxArgs(char ma)
 {
 	maxArgs = ma;
 }
 
 //////////////////////////////////////////////////////////////////////////////
-char getMaxArgs()
+char SimpleSerialShell::getMaxArgs()
 {
 	return maxArgs;
 }

--- a/src/SimpleSerialShell.cpp
+++ b/src/SimpleSerialShell.cpp
@@ -85,12 +85,25 @@ SimpleSerialShell::SimpleSerialShell()
       m_lastErrNo(EXIT_SUCCESS),
       tokenizer(strtok_r)
 {
+	maxArgs = MAXARGS;
     resetBuffer();
 
     // simple help.
     addCommand(F("help"), SimpleSerialShell::printHelp);
 };
 
+//////////////////////////////////////////////////////////////////////////////
+void setMaxArgs(char ma)
+{
+	maxArgs = ma;
+}
+
+//////////////////////////////////////////////////////////////////////////////
+char getMaxArgs()
+{
+	return maxArgs;
+}
+	
 //////////////////////////////////////////////////////////////////////////////
 void SimpleSerialShell::addCommand(
     const __FlashStringHelper * name, CommandFunction f)
@@ -215,7 +228,7 @@ int SimpleSerialShell::execute(const char commandString[])
 //////////////////////////////////////////////////////////////////////////////
 int SimpleSerialShell::execute(void)
 {
-    char * argv[MAXARGS] = {0};
+    char * argv[maxArgs] = {0};
     linebuffer[SIMPLE_SERIAL_SHELL_BUFSIZE - 1] = '\0'; // play it safe
     int argc = 0;
 
@@ -232,7 +245,7 @@ int SimpleSerialShell::execute(void)
     }
     argv[argc++] = commandName;
 
-    for ( ; argc < MAXARGS; )
+    for ( ; argc < maxArgs; )
     {
         char * anArg = tokenizer(0, whitespace, &rest);
         if (anArg) {

--- a/src/SimpleSerialShell.h
+++ b/src/SimpleSerialShell.h
@@ -82,6 +82,11 @@ class SimpleSerialShell : public Stream {
         // optional.
         void setTokenizer(TokenizerFunction f);
 
+		// Sets the maximum number of arguments for commands
+		void setMaxArgs(char ma);
+		// Gets the maximum number of arguments for commands
+		char getMaxArgs();
+		
     private:
 
         SimpleSerialShell(void);
@@ -95,6 +100,7 @@ class SimpleSerialShell : public Stream {
 
         int report(const __FlashStringHelper * message, int errorCode);
         static const char MAXARGS = 10;
+		char maxArgs;
         char linebuffer[SIMPLE_SERIAL_SHELL_BUFSIZE];
         int inptr;
 


### PR DESCRIPTION

See https://github.com/philj404/SimpleSerialShell/issues/42

The current value (10) seems too restrictive.
Relatively simple commands like person add -name Paul -age 21 -gen M -nat US -enabled fail.
Is it possible to modify the code so that this value can be changed? (Perhaps with precompiler directives, or maybe better, as a class member)